### PR TITLE
Release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Version changelog
 
+## 0.1.0
+
+* Added install instructions ([#23](https://github.com/databrickslabs/sandbox/pull/23)).
+* Added more go-git libs ([#26](https://github.com/databrickslabs/sandbox/pull/26)).
+* Fixed `unsupported protocol scheme` error ([#27](https://github.com/databrickslabs/sandbox/pull/27)).
+* Modified README to say how to use it with `databricks labs sandbox` command ([#25](https://github.com/databrickslabs/sandbox/pull/25)).
+* More git-related libraries ([#30](https://github.com/databrickslabs/sandbox/pull/30)).
+
+Dependency updates:
+
+ * Bump golang.org/x/crypto from 0.16.0 to 0.17.0 in /go-libs ([#28](https://github.com/databrickslabs/sandbox/pull/28)).
+ * Bump golang.org/x/crypto from 0.16.0 to 0.17.0 in /runtime-packages ([#29](https://github.com/databrickslabs/sandbox/pull/29)).
+
 ## 0.0.1
 
 Initial version with some tooling.


### PR DESCRIPTION

* Added install instructions ([#23](https://github.com/databrickslabs/sandbox/pull/23)).
* Added more go-git libs ([#26](https://github.com/databrickslabs/sandbox/pull/26)).
* Fixed `unsupported protocol scheme` error ([#27](https://github.com/databrickslabs/sandbox/pull/27)).
* Modified README to say how to use it with `databricks labs sandbox` command ([#25](https://github.com/databrickslabs/sandbox/pull/25)).
* More git-related libraries ([#30](https://github.com/databrickslabs/sandbox/pull/30)).

Dependency updates:

 * Bump golang.org/x/crypto from 0.16.0 to 0.17.0 in /go-libs ([#28](https://github.com/databrickslabs/sandbox/pull/28)).
 * Bump golang.org/x/crypto from 0.16.0 to 0.17.0 in /runtime-packages ([#29](https://github.com/databrickslabs/sandbox/pull/29)).

