### PR TITLE
Run single test with `pytest`

### DIFF
--- a/acceptance/ecosystem/pytest_run_one.py
+++ b/acceptance/ecosystem/pytest_run_one.py
@@ -1,0 +1,33 @@
+import os
+import pytest
+
+class RunOne:
+    def pytest_collection_modifyitems(self, items: list[pytest.Item], config: pytest.Config):
+        deselected = []
+        remaining = []
+        for item in items:
+            # Otherwise we have ERROR: Wrong expression passed to '-k': 
+            #   test_uploading_notebooks_get_correct_urls[py-# Databricks notebook source]: 
+            #   at column 46: unexpected character "#"
+            # See https://github.com/pytest-dev/pytest/issues/12018
+            if item.name != os.environ['TEST_FILTER']:
+                deselected.append(item)
+                continue
+            remaining.append(item)
+        if not deselected:
+            return
+        config.hook.pytest_deselected(items=deselected)
+        items[:] = remaining
+
+if __name__ == '__main__':
+    pytest.main([
+        "-n0",                                      # no xdist, single-threaded
+		"--timeout", "1800",                        # fail in 30 minutes
+		"--log-cli-level", "DEBUG",                 # log everything
+		"--log-level", "DEBUG",                     # log everything
+		"--log-disable", "urllib3.connectionpool",  # except noise
+		"--log-format", "%(asctime)s %(levelname)s [%(name)s] %(message)s",
+		"--log-date-format", "%H:%M",
+		"--no-header",
+		"--no-summary",
+    ], plugins=[RunOne()])

--- a/acceptance/redaction/redaction.go
+++ b/acceptance/redaction/redaction.go
@@ -40,7 +40,7 @@ func (r Redaction) Copy(dst io.Writer, src io.Reader) (written int64, err error)
 		// less risks of a secret spanning multiple lines
 		// (unless it's a base64-encoded key)
 		line := r.ReplaceAll(string(scanner.Bytes()))
-		n, err := dst.Write([]byte(line))
+		n, err := dst.Write([]byte(line + "\n"))
 		if err != nil {
 			return written, err
 		}


### PR DESCRIPTION
This pull request includes changes to the `acceptance/ecosystem/golang.go` and `acceptance/ecosystem/python.go` files, adding new methods to existing types and changing the implementation of some existing methods. 

In `acceptance/ecosystem/golang.go`, the `GoTestRunner` type has been modified to include a new field `files` of type `fileset.FileSet`. The `Detect` method has been changed to use the new `files` field instead of the `files` parameter. The `ListAll` method has also been changed to use the new `files` field. The `RunOne` method has been changed to take a `files` parameter of type `fileset.FileSet`, but this parameter is not used in the method implementation, and the method calls `r.files.FirstMatch` instead.

In `acceptance/ecosystem/python.go`, the `pyTestRunner` type has been modified to include a new field `files` of type `fileset.FileSet`. The `Detect` method has been changed to use the new `files` field instead of the `files` parameter. The `ListAll` method has been changed to use the new `files` field. The `prepare` method has been modified to use the new `logfile` parameter instead of the `files` parameter. The `RunOne` method has been changed to take a `logfile` parameter instead of the `files` parameter, and it now calls `r.files.FirstMatch` instead of `files.FirstMatch`. The `RunAll` method has been modified to use the new `logfile` parameter instead of the `files` parameter.

This pull request also includes a new file, `acceptance/ecosystem/pytest_run_one.py`, which is a plugin for pytest that modifies the behavior of the `pytest` command when run with the `-k` option. This plugin filters tests based on the name of the test, using the value of the `TEST_FILTER` environment variable.
