### PR TITLE
Simplify error output from `pytest` 

### DIFF
--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -21,6 +21,8 @@ tags:
     - [`go-coverprofile`](#go-coverprofile)
     - [`go-test.out`](#go-testout)
     - [`go-test.err`](#go-testerr)
+    - [`pytest-*.out`](#pytest-out)
+  - [Usage as library](#usage-as-library)
   - [Troubleshooting](#troubleshooting)
   - [Releasing](#releasing)
 
@@ -150,6 +152,37 @@ go: downloading github.com/fatih/color v1.16.0
 go: downloading github.com/spf13/pflag v1.0.5
 go: downloading github.com/spf13/viper v1.18.2
 go: downloading github.com/stretchr/testify v1.8.4
+```
+
+### `pytest-*.out`
+
+Standard output from `pytest`.
+
+## Usage as library
+
+See [`main.go`](main.go) for the example on how to use it within GitHub Action. This is how you can use it in your CLI:
+
+```go
+testEnv := testenv.NewWithAzureCLI(vaultURI)
+loaded, err := testEnv.Load(ctx)
+if err != nil {
+  return fmt.Errorf("load: %w", err)
+}
+ctx, stop, err := loaded.Start(ctx)
+if err != nil {
+  return fmt.Errorf("start: %w", err)
+}
+defer stop()
+cwd, err := os.Getwd()
+if err != nil {
+  return fmt.Errorf("cwd: %w", err)
+}
+// detect and run all tests
+report, err := ecosystem.RunAll(ctx, loaded.Redaction(), cwd)
+if err != nil {
+  return fmt.Errorf("test: %w", err)
+}
+return fmt.Errorf("failed: %s", report.String())
 ```
 
 ## Troubleshooting

--- a/acceptance/ecosystem/pytest_run.py
+++ b/acceptance/ecosystem/pytest_run.py
@@ -43,7 +43,7 @@ class RunReport:
             self._failed[report.location] = True
         if report.skipped:
             self._skipped[report.location] = True
-            self._duration[report.location] += report.duration
+        self._duration[report.location] += report.duration
 
 
 if __name__ == '__main__':

--- a/acceptance/ecosystem/pytest_run.py
+++ b/acceptance/ecosystem/pytest_run.py
@@ -6,6 +6,7 @@ import collections
 
 class RunReport:
     _logs = collections.defaultdict(list)
+    _failures = collections.defaultdict(list)
     _failed = collections.defaultdict(bool)
     _skipped = collections.defaultdict(bool)
     _duration = collections.defaultdict(float)
@@ -17,22 +18,32 @@ class RunReport:
             'name': name,
             'pass': not self._failed[location],
             'skip': self._skipped[location],
-            'output': "\n".join(self._logs[location]),
+            'output': "\n".join(self._failures[location] + self._logs[location]),
             'elapsed': self._duration[location],
         })
 
     def pytest_runtest_logreport(self, report: pytest.TestReport):
         if report.caplog:
             self._logs[report.location].append(report.caplog)
-        if report.longreprtext:
-            # longrepr can be either a tuple or an exception. 
+        if report.longrepr and hasattr(report.longrepr, 'reprcrash'):
+            repr_crash = report.longrepr.reprcrash
+            if hasattr(repr_crash, 'message'):
+                message = repr_crash.message
+            else:
+                message = f'unknown: {repr_crash}'
+            self._failures[report.location].append(message)
+        elif report.longrepr and isinstance(report.longrepr, tuple) and len(report.longrepr) == 3:
+            message = report.longrepr[2]
+            self._failures[report.location].append(message)
+        elif report.longreprtext:
+            # longrepr can be either a tuple or an exception.
             # we need to make it more friendly to one-line repr in CLI
             self._logs[report.location].append(report.longreprtext)
         if not report.passed:
             self._failed[report.location] = True
         if report.skipped:
             self._skipped[report.location] = True
-        self._duration[report.location] += report.duration
+            self._duration[report.location] += report.duration
 
 
 if __name__ == '__main__':

--- a/acceptance/ecosystem/python.go
+++ b/acceptance/ecosystem/python.go
@@ -123,7 +123,7 @@ func (r pyTestRunner) ListAll(ctx context.Context) []string {
 	defer cancel()
 	reply := newLocalHookServer(ctx)
 	defer reply.Close()
-	py, err := r.prepare(ctx, redaction.Redaction{}, "pytest.log")
+	py, err := r.prepare(ctx, redaction.Redaction{}, "pytest-collect.out")
 	if err != nil {
 		logger.Warnf(ctx, ".codegen.json: %s", err)
 		return nil
@@ -146,7 +146,7 @@ func (r pyTestRunner) ListAll(ctx context.Context) []string {
 var nonAlphanumRegex = regexp.MustCompile(`[^a-zA-Z0-9-]+`)
 
 func (r pyTestRunner) RunOne(ctx context.Context, redact redaction.Redaction, one string) error {
-	logfile := fmt.Sprintf("debug-%s.log", nonAlphanumRegex.ReplaceAllString(one, "_"))
+	logfile := fmt.Sprintf("pytest-%s.out", nonAlphanumRegex.ReplaceAllString(one, "_"))
 	py, err := r.prepare(ctx, redact, logfile)
 	if err != nil {
 		return fmt.Errorf(".codegen.json: %w", err)
@@ -171,7 +171,7 @@ func (r pyTestRunner) RunAll(ctx context.Context, redact redaction.Redaction) (T
 	defer cancel()
 	reply := newLocalHookServer(ctx)
 	defer reply.Close()
-	py, err := r.prepare(ctx, redact, "pytest.log")
+	py, err := r.prepare(ctx, redact, "pytest-all.out")
 	if err != nil {
 		return nil, fmt.Errorf(".codegen.json: %w", err)
 	}

--- a/acceptance/ecosystem/report.go
+++ b/acceptance/ecosystem/report.go
@@ -21,7 +21,14 @@ type TestResult struct {
 }
 
 func (tr TestResult) String() string {
-	return fmt.Sprintf("%s %s (%0.3fs)", tr.icon(), tr.Name, tr.Elapsed)
+	summary := ""
+	if !tr.Pass {
+		header, _, ok := strings.Cut(tr.Output, "\n")
+		if ok {
+			summary = fmt.Sprintf(": %s", header)
+		}
+	}
+	return fmt.Sprintf("%s %s%s (%0.3fs)", tr.icon(), tr.Name, summary, tr.Elapsed)
 }
 func (tr TestResult) icon() string {
 	if tr.Skip {


### PR DESCRIPTION
Error summary is more readable now:

```
20:12  INFO ❌ test_install_folder_custom: AssertionError: assert '/custom/folder' != '/custom/folder' (0.000s)
20:12  INFO ✅ test_no_state (0.000s)
```