### PR TITLE
Recover from flaky tests

### DIFF
--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -113,8 +113,8 @@ GitHub Actions raw event information. Example:
 Normalised integration test execution report across all ecosystems. Example:
 
 ```json
-{"ts":"2024-02-03T15:28:16.940198637Z","project":"go-libs","package":"sqlexec","name":"TestAccErrorMapping","pass":false,"skip":true,"output":"=== RUN   TestAccErrorMapping\n    init.go:96: Environment variable CLOUD_ENV is missing\n--- SKIP: TestAccErrorMapping (0.00s)\n","elapsed":0}
-{"ts":"2024-02-03T15:28:16.940348556Z","project":"go-libs","package":"sqlexec","name":"TestAccMultiChunk","pass":false,"skip":true,"output":"=== RUN   TestAccMultiChunk\n    init.go:96: Environment variable CLOUD_ENV is missing\n--- SKIP: TestAccMultiChunk (0.00s)\n","elapsed":0}
+{"ts":"2024-02-03T15:28:16.940198637Z","project":"go-libs","package":"sqlexec","name":"TestAccErrorMapping","flaky":false,"pass":false,"skip":true,"output":"=== RUN   TestAccErrorMapping\n    init.go:96: Environment variable CLOUD_ENV is missing\n--- SKIP: TestAccErrorMapping (0.00s)\n","elapsed":0}
+{"ts":"2024-02-03T15:28:16.940348556Z","project":"go-libs","package":"sqlexec","name":"TestAccMultiChunk","flaky":true,"pass":true,"skip":false,"output":"...","elapsed":0}
 ```
 
 ### `go-coverprofile`

--- a/acceptance/ecosystem/pytest_run.py
+++ b/acceptance/ecosystem/pytest_run.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import pytest
 import requests
 import collections
@@ -47,4 +48,9 @@ class RunReport:
 
 
 if __name__ == '__main__':
-    pytest.main(['-n', '10'], plugins=[RunReport()])
+    sys.exit(pytest.main([
+        '-n', '10',
+        "--log-disable", "urllib3.connectionpool",
+        "--log-format", "%(asctime)s %(levelname)s [%(name)s] %(message)s",
+        "--log-date-format", "%H:%M",
+    ], plugins=[RunReport()]))

--- a/acceptance/ecosystem/pytest_run_one.py
+++ b/acceptance/ecosystem/pytest_run_one.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import pytest
 
 class RunOne:
@@ -20,7 +21,7 @@ class RunOne:
         items[:] = remaining
 
 if __name__ == '__main__':
-    pytest.main([
+    sys.exit(pytest.main([
         "-n0",                                      # no xdist, single-threaded
 		"--timeout", "1800",                        # fail in 30 minutes
 		"--log-cli-level", "DEBUG",                 # log everything
@@ -30,4 +31,4 @@ if __name__ == '__main__':
 		"--log-date-format", "%H:%M",
 		"--no-header",
 		"--no-summary",
-    ], plugins=[RunOne()])
+    ], plugins=[RunOne()]))

--- a/acceptance/ecosystem/runner.go
+++ b/acceptance/ecosystem/runner.go
@@ -2,8 +2,11 @@ package ecosystem
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os/exec"
 
+	"github.com/databricks/databricks-sdk-go/logger"
 	"github.com/databrickslabs/sandbox/acceptance/redaction"
 	"github.com/databrickslabs/sandbox/go-libs/fileset"
 )
@@ -39,5 +42,26 @@ func RunAll(ctx context.Context, redact redaction.Redaction, folder string) (Tes
 	if err != nil {
 		return nil, fmt.Errorf("ecosystem: %w", err)
 	}
-	return runner.RunAll(ctx, redact)
+	report, err := runner.RunAll(ctx, redact)
+	// 0 - all passed, 1 - some failed, 2 - interrupted
+	// See: https://docs.pytest.org/en/4.6.x/usage.html
+	// See: https://github.com/golang/go/issues/25989
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() > 1 {
+		return nil, exitErr
+	}
+	// sequential de-flake loop
+	for i, result := range report {
+		if result.Pass || result.Skip {
+			continue
+		}
+		logger.Infof(ctx, "⛑️ re-running: %s", result.Name)
+		rerunErr := runner.RunOne(ctx, redact, result.Name)
+		if rerunErr == nil {
+			report[i].Flaky = true
+			report[i].Pass = true
+			logger.Warnf(ctx, "🥴 flaky test detected: %s", result.Name)
+		}
+	}
+	return report, nil
 }


### PR DESCRIPTION
This pull request includes changes to both the implementation and the test code in the `acceptance` directory.

The `report.go` file has been updated to include a new `Flaky` field in the `TestResult` struct, which indicates whether a test result was flaky or not. The `TestReport` struct has also been updated to include a new `Flaky` method that checks whether any of the test results are flaky or not. The `Failed` method has been updated to return an error if any of the test results are not passed. The `StepSummary` method has been updated to display flaky test results separately.

The `runner.go` file has been updated to include a sequential de-flake loop that re-runs any failed tests that are marked as flaky. If the re-run passes, the test result is marked as flaky and the test report is updated accordingly.

The `pytest_run.py` and `pytest_run_one.py` files in the `ecosystem` directory have been updated to include additional logging options when running tests using pytest. Specifically, the `--log-disable`, `--log-format`, `--log-date-format`, `--no-header`, and `--no-summary` options have been added to the pytest command line arguments.

The `report.go` file has been updated to include a new `Flaky` field in the `TestResult` struct, which is used to indicate whether a test result was flaky or not. The `TestReport` struct has been updated to include a new `Flaky` method that checks whether any of the test results are flaky or not.

Overall, this pull request updates the test reporting and adds a sequential de-flake loop to handle flaky tests, while also updating the test logging options for pytest.