### PR TITLE
Added configurable skipping of release notes commits

### DIFF
--- a/go-libs/lite/lite.go
+++ b/go-libs/lite/lite.go
@@ -221,6 +221,12 @@ func (r *Root[T]) bindViperToFlags(v *viper.Viper, flags *pflag.FlagSet, prefix 
 				for _, y := range x {
 					sliceValue.Append(fmt.Sprint(y))
 				}
+			case []string:
+				sliceValue, ok := f.Value.(pflag.SliceValue)
+				if !ok {
+					err = fmt.Errorf("%s: expected string slice, but got %s", propName, f.Value.String())
+				}
+				sliceValue.Replace(x)
 			default:
 				f.Value.Set(fmt.Sprintf("%v", x))
 			}

--- a/go-libs/llnotes/talk.go
+++ b/go-libs/llnotes/talk.go
@@ -14,12 +14,14 @@ import (
 )
 
 type Settings struct {
-	GitHub     github.GitHubConfig
-	Databricks config.Config
-	Org, Repo  string
-	Model      string
-	MaxTokens  int
-	Workers    int
+	GitHub      github.GitHubConfig
+	Databricks  config.Config
+	Org, Repo   string
+	Model       string
+	MaxTokens   int
+	Workers     int
+	SkipLabels  []string
+	SkipCommits []string
 }
 
 func New(cfg *Settings) (*llNotes, error) {
@@ -36,6 +38,9 @@ func New(cfg *Settings) (*llNotes, error) {
 	}
 	if cfg.Workers == 0 {
 		cfg.Workers = 15
+	}
+	if len(cfg.SkipLabels) == 0 {
+		cfg.SkipLabels = []string{"internal"}
 	}
 	return &llNotes{
 		http:  httpclient.NewApiClient(httpclient.ClientConfig{}),


### PR DESCRIPTION
* by default, if `internal` label is attached to a PR, it won't appear in the release notes
* it's also now possible to skip individual commit SHA's