### PR TITLE
update tableau connector required version

### DIFF
--- a/tableau-delta-sharing-connector-oauth/README.md
+++ b/tableau-delta-sharing-connector-oauth/README.md
@@ -8,8 +8,8 @@ The connector is built with the Tableau Web Data Connector 3.0 SDK and provides:
 ## Prerequisite
 - [Python 3.7 or higher](https://www.python.org/downloads/)
 - [JDK 11 or higher](https://www.oracle.com/java/technologies/downloads/)
-- [Tableau Desktop 2024.1 or later](https://www.tableau.com/support/releases/desktop/2024.1)
-- Install [taco-toolkit](https://help.tableau.com/current/api/webdataconnector/en-us/index.html): `npm install -g @tableau/taco-toolkit@tableau-2024.1`
+- [Tableau Desktop 2023.3.14 or later](https://www.tableau.com/support/releases/desktop/2023.3.14)
+- Install [taco-toolkit](https://help.tableau.com/current/api/webdataconnector/en-us/index.html): `npm install -g @tableau/taco-toolkit@2.0.0`
 
 ## Local Test
 
@@ -36,3 +36,6 @@ E.g. for Okta: https://developer.okta.com/docs/guides/implement-oauth-for-okta/m
 
 ## Run in Tableau
 Please refer to [Tableau doc](https://tableau.github.io/connector-plugin-sdk/docs/run-taco)
+
+## Limitations
+Please refer to [Databricks doc](https://docs.databricks.com/aws/en/delta-sharing/read-data-open#limitations-of-the-tableau-delta-sharing-connector)

--- a/tableau-delta-sharing-connector-oauth/connector/connector.json
+++ b/tableau-delta-sharing-connector-oauth/connector/connector.json
@@ -2,7 +2,7 @@
   "name": "Delta Sharing OAuth",
   "version": "1.0.0",
   "tableau-version": {
-    "min": "2024.1"
+    "min": "2023.3.14"
   },
   "vendor": {
     "name": "Databricks",

--- a/tableau-delta-sharing-connector-oauth/connector/package.json
+++ b/tableau-delta-sharing-connector-oauth/connector/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@popperjs/core": "^2.11.8",
-    "@tableau/taco-toolkit": "2.1.0",
+    "@tableau/taco-toolkit": "2.0.0",
     "bootstrap": "^5.3.0",
     "font-awesome": "^4.7.0",
     "react": "^18.0.0",


### PR DESCRIPTION
# Update Tableau Connector Required Version

## Proposed Changes
- Updated minimum Tableau version requirement from 2024.1 to 2023.3.14 in connector.json
- Updated taco-toolkit dependency from version 2.1.0 to 2.0.0 in package.json
- Updated documentation in README.md to reflect the new minimum Tableau version (2023.3)
- Added a reference to Databricks documentation about connector limitations in README.md

## Why
This change improves compatibility by supporting older Tableau versions (2023.3 and later), making the connector accessible to a wider range of users who may not have upgraded to the 2024.1 version yet.

## How is this tested
The connector has been verified to work correctly with Tableau 2023.3 versions while maintaining all functionality.

## Additional Information
The updated version requirements align with the broader compatibility goals for the Delta Sharing connector while ensuring all features continue to work as expected.
