### PR TITLE
Add GH workflow to check if commits are signed

### DIFF
--- a/.github/workflows/check-if-commit-signed.yml
+++ b/.github/workflows/check-if-commit-signed.yml
@@ -1,0 +1,16 @@
+name: Check signed commits in PR
+on: pull_request_target
+
+jobs:
+  check-signed-commits:
+    name: Check signed commits in PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Check signed commits in PR
+        uses: 1Password/check-signed-commits-action@v1
+        with:
+          comment: |
+            All commits in PR should be signed (`git commit -S ...`). See https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits


### PR DESCRIPTION
There were already multiple occasions when PRs were approved but they couldn't be merged because commits aren't signed.  This PR adds the explicit check that will fail if commits in the PR aren't signed.  It uses the
https://github.com/marketplace/actions/check-signed-commits-in-pr action from GH marketplace.