### PR TITLE
Fix missing return in acceptance metadata server after 400 reply

### DIFF
--- a/acceptance/testenv/loaded.go
+++ b/acceptance/testenv/loaded.go
@@ -151,6 +151,7 @@ func (l *loadedEnv) metadataServer(seed *config.Config) *httptest.Server {
 				ErrorCode: "BAD_REQUEST",
 				Message:   "Wrong Authorization header",
 			})
+			return
 		}
 		// try parse expiry date from JWT token
 		exp, err := l.parseExpiryDate(ctx, accessToken)


### PR DESCRIPTION
## Summary

- Fixed missing return in acceptance metadata server after 400 reply. Without the return, after replying 400 the handler keeps executing: it calls parseExpiryDate with an empty accessToken, then writes a second response (200 with an msiToken whose TokenType/AccessToken are empty strings) - producing a malformed response

## Test plan

- [ ] `go build ./...` in `acceptance/`
- [ ] Existing acceptance action integration tests still pass
- [ ] Downstream flakiness (occasional `401: Credential was not sent or was of an unsupported type for this API` under parallel test runs) no longer reproduces

Observed downstream in the DQX anomaly integration test suite (parallel `pytest-xdist` workers, Azure metadata-service auth via this action). This would require new release of acceptance action.