### PR TITLE
Parametrize acceptance action with pytest parallel worker count

### DIFF
--- a/acceptance/action.yml
+++ b/acceptance/action.yml
@@ -27,6 +27,10 @@ inputs:
   codegen_path:
     description: 'Relative path to the .codegen.json file to use for configuring the acceptance tests'
     required: false  # by default the first .codegen.json found in the project is used
+  n:
+    description: 'Number of parallel pytest workers (pytest-xdist -n).'
+    required: false
+    default: '10'
 outputs:
   sample:
     description: 'Sample output'

--- a/acceptance/ecosystem/pytest_run.py
+++ b/acceptance/ecosystem/pytest_run.py
@@ -49,7 +49,7 @@ class RunReport:
 
 if __name__ == '__main__':
     sys.exit(pytest.main([
-        '-n', os.environ.get('PYTEST_N', '10'),
+        '-n', (os.environ.get('PYTEST_N') or '').strip() or '10',
         "--log-disable", "urllib3.connectionpool",
         "--log-format", "%(asctime)s %(levelname)s [%(name)s] %(message)s",
         "--log-date-format", "%H:%M",

--- a/acceptance/ecosystem/pytest_run.py
+++ b/acceptance/ecosystem/pytest_run.py
@@ -49,7 +49,7 @@ class RunReport:
 
 if __name__ == '__main__':
     sys.exit(pytest.main([
-        '-n', '10',
+        '-n', os.environ.get('PYTEST_N', '10'),
         "--log-disable", "urllib3.connectionpool",
         "--log-format", "%(asctime)s %(levelname)s [%(name)s] %(message)s",
         "--log-date-format", "%H:%M",

--- a/acceptance/main.go
+++ b/acceptance/main.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -71,7 +72,12 @@ func (a *acceptance) trigger(ctx context.Context) (*notify.Notification, error) 
 	// set codegen path file used for configuring the acceptance tests
 	codegenPath := a.Action.GetInput("codegen_path")
 	ctx = env.Set(ctx, "codegen_path", codegenPath)
-	if n := a.Action.GetInput("n"); n != "" {
+	if n := strings.TrimSpace(a.Action.GetInput("n")); n != "" {
+		if n != "auto" {
+			if v, err := strconv.Atoi(n); err != nil || v < 1 {
+				return nil, fmt.Errorf("invalid n %q: expected positive integer or \"auto\"", n)
+			}
+		}
 		ctx = env.Set(ctx, "PYTEST_N", n)
 	}
 	redact := loaded.Redaction()

--- a/acceptance/main.go
+++ b/acceptance/main.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -72,10 +71,7 @@ func (a *acceptance) trigger(ctx context.Context) (*notify.Notification, error) 
 	// set codegen path file used for configuring the acceptance tests
 	codegenPath := a.Action.GetInput("codegen_path")
 	ctx = env.Set(ctx, "codegen_path", codegenPath)
-	if n := strings.TrimSpace(a.Action.GetInput("n")); n != "" {
-		if v, err := strconv.Atoi(n); err != nil || v < 1 {
-			return nil, fmt.Errorf("invalid n %q: expected positive integer", n)
-		}
+	if n := a.Action.GetInput("n"); n != "" {
 		ctx = env.Set(ctx, "PYTEST_N", n)
 	}
 	redact := loaded.Redaction()

--- a/acceptance/main.go
+++ b/acceptance/main.go
@@ -71,6 +71,9 @@ func (a *acceptance) trigger(ctx context.Context) (*notify.Notification, error) 
 	// set codegen path file used for configuring the acceptance tests
 	codegenPath := a.Action.GetInput("codegen_path")
 	ctx = env.Set(ctx, "codegen_path", codegenPath)
+	if n := a.Action.GetInput("n"); n != "" {
+		ctx = env.Set(ctx, "PYTEST_N", n)
+	}
 	redact := loaded.Redaction()
 	report, err := a.runWithTimeout(ctx, redact, directory)
 	if err != nil {

--- a/acceptance/main.go
+++ b/acceptance/main.go
@@ -73,10 +73,8 @@ func (a *acceptance) trigger(ctx context.Context) (*notify.Notification, error) 
 	codegenPath := a.Action.GetInput("codegen_path")
 	ctx = env.Set(ctx, "codegen_path", codegenPath)
 	if n := strings.TrimSpace(a.Action.GetInput("n")); n != "" {
-		if n != "auto" {
-			if v, err := strconv.Atoi(n); err != nil || v < 1 {
-				return nil, fmt.Errorf("invalid n %q: expected positive integer or \"auto\"", n)
-			}
+		if v, err := strconv.Atoi(n); err != nil || v < 1 {
+			return nil, fmt.Errorf("invalid n %q: expected positive integer", n)
 		}
 		ctx = env.Set(ctx, "PYTEST_N", n)
 	}

--- a/acceptance/main_test.go
+++ b/acceptance/main_test.go
@@ -12,6 +12,7 @@ func TestXxx(t *testing.T) {
 	t.Skip()
 	ctx := context.Background()
 	ctx = env.Set(ctx, "INPUT_DIRECTORY", "../go-libs")
+	ctx = env.Set(ctx, "INPUT_N", "4")
 	err := run(ctx)
 	assert.NoError(t, err)
 }

--- a/acceptance/main_test.go
+++ b/acceptance/main_test.go
@@ -12,7 +12,7 @@ func TestXxx(t *testing.T) {
 	t.Skip()
 	ctx := context.Background()
 	ctx = env.Set(ctx, "INPUT_DIRECTORY", "../go-libs")
-	ctx = env.Set(ctx, "INPUT_N", "4")
+	ctx = env.Set(ctx, "INPUT_N", "4")  // verify PYTEST_N=4 in pytest output
 	err := run(ctx)
 	assert.NoError(t, err)
 }

--- a/acceptance/staticcheck.conf
+++ b/acceptance/staticcheck.conf
@@ -1,4 +1,0 @@
-# Ignore SA1019 (deprecated symbol) globally — the Databricks SDK deprecated
-# cfg.Environment() in favor of the Cloud field and IsAws/IsAzure/IsGcp helpers.
-# The migration is tracked separately; until then the deprecation noise would gate `make fmt`.
-checks = ["inherit", "-SA1019"]

--- a/acceptance/staticcheck.conf
+++ b/acceptance/staticcheck.conf
@@ -1,0 +1,4 @@
+# Ignore SA1019 (deprecated symbol) globally — the Databricks SDK deprecated
+# cfg.Environment() in favor of the Cloud field and IsAws/IsAzure/IsGcp helpers.
+# The migration is tracked separately; until then the deprecation noise would gate `make fmt`.
+checks = ["inherit", "-SA1019"]

--- a/acceptance/testenv/githubOidc.go
+++ b/acceptance/testenv/githubOidc.go
@@ -73,7 +73,7 @@ func (cpf *credentialsProviderFunc) SetHeaders(r *http.Request) error {
 
 // Configure implements credentials provider for Databricks SDK
 func (c *ghOidcCreds) Configure(ctx context.Context, cfg *config.Config) (credentials.CredentialsProvider, error) {
-	ts, err := c.oidcTokenSource(ctx, cfg.Environment().AzureApplicationID)
+	ts, err := c.oidcTokenSource(ctx, environment.GetEnvironmentForHostname(cfg.CanonicalHostName()).AzureApplicationID)
 	if err != nil {
 		return nil, fmt.Errorf("oidc: %w", err)
 	}

--- a/acceptance/testenv/loaded.go
+++ b/acceptance/testenv/loaded.go
@@ -71,7 +71,7 @@ func (l *loadedEnv) Cloud() environment.Cloud {
 	if err != nil {
 		return environment.CloudAWS
 	}
-	return cfg.Environment().Cloud
+	return environment.GetEnvironmentForHostname(cfg.CanonicalHostName()).Cloud
 }
 
 func (l *loadedEnv) Start(ctx context.Context) (context.Context, func(), error) {
@@ -80,7 +80,8 @@ func (l *loadedEnv) Start(ctx context.Context) (context.Context, func(), error) 
 		return nil, nil, fmt.Errorf("config: %w", err)
 	}
 	srv := l.metadataServer(cfg)
-	ctx = env.Set(ctx, "CLOUD_ENV", strings.ToLower(string(cfg.Environment().Cloud)))
+	cloud := environment.GetEnvironmentForHostname(cfg.CanonicalHostName()).Cloud
+	ctx = env.Set(ctx, "CLOUD_ENV", strings.ToLower(string(cloud)))
 	ctx = env.Set(ctx, "DATABRICKS_METADATA_SERVICE_URL", fmt.Sprintf("%s/%s", srv.URL, l.mpath))
 	ctx = env.Set(ctx, "DATABRICKS_AUTH_TYPE", "metadata-service")
 	isAuth := map[string]bool{}
@@ -104,7 +105,7 @@ func (l *loadedEnv) Start(ctx context.Context) (context.Context, func(), error) 
 }
 
 func (l *loadedEnv) metadataServer(seed *config.Config) *httptest.Server {
-	accountHost := seed.Environment().DeploymentURL("accounts")
+	accountHost := environment.GetEnvironmentForHostname(seed.CanonicalHostName()).DeploymentURL("accounts")
 	configurations := map[string]*config.Config{
 		seed.CanonicalHostName(): seed,
 		accountHost: {


### PR DESCRIPTION
## Summary
- Add a new `n` input to the acceptance GitHub Action (default `10`) for configuring pytest-xdist parallel workers. Propagates via the `PYTEST_N` env var to `pytest_run.py`; Go tests are unaffected.
- Updated depreciated sdk methods to fix `make fmt`

## Test plan
- [x] `make fmt` passes locally
- [x] `make test` passes locally
- [x] Run the action in a downstream repo with `n: '4'` and confirm pytest uses `-n 4`
- [x] Run the action without setting `n` and confirm default of `10`

Context: we need to be able to reduce parallel test execution in DQX as 10 parallel runs creates a high contention of testing clusters. This would require a new release.